### PR TITLE
[FEAT#40] BE_프로필 이메일 가져오기

### DIFF
--- a/Schello/settings.py
+++ b/Schello/settings.py
@@ -178,7 +178,8 @@ STATICFILES_DIRS = [
 ]
 
 # allauth에서 이메일 가져오지 않게 설정
-ACCOUNT_EMAIL_VERIFICATION = "none"
+ACCOUNT_SIGNUP_FIELDS = ['email*', 'username*', 'password1*', 'password2*']
+ACCOUNT_EMAIL_VERIFICATION = "none"  # 또는 'mandatory'
 SOCIALACCOUNT_QUERY_EMAIL = True
 
 


### PR DESCRIPTION
## 📣 작업 개요
프로필 페이지에 이메일 가져오기

## 𝌡 주요 변경 사항
- 프로필 페이지에 이메일 정보 띄움

## 🧪 테스트 방법
1. http://localhost:8000/accounts/kakao/login/ 접속
2. 로그인 버튼 클릭 → 카카오 계정 연동
3. 회원가입 or 로그인 자동 처리됨
4. accounts/profile/ 접속